### PR TITLE
Update grgit and remove jcenter references from build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.8.1"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.32.0"
     }
 }
 
@@ -15,13 +15,13 @@ ext {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'org.ajoberstar.grgit:grgit-core:4.0.1'
+    compile 'org.ajoberstar.grgit:grgit-core:4.1.1'
     compile "org.eclipse.jgit:org.eclipse.jgit.ui:${jgitVersion}"
     compile "org.eclipse.jgit:org.eclipse.jgit:${jgitVersion}"
     compile 'org.tmatesoft.svnkit:svnkit:1.8.12'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 // Empty settings file to allow wrapper to be used within this psuedo sub-prject
+rootProject.name="versioning"


### PR DESCRIPTION
`grgit` 4.0.1 has disappeared. Need to use a newer version. 4.1.1 is the latest available 4.x release and shouldn't break anything.